### PR TITLE
Capture screenshot improvement for alerts and disappearing windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<hamcrest-library.version>1.3</hamcrest-library.version>
 		<junit.version>4.11</junit.version>
 		<rest-assured.version>2.7.0</rest-assured.version>
-		<selenium-java.version>2.51.0</selenium-java.version>
+		<selenium-java.version>2.53.0</selenium-java.version>
 
 		<log4j.version>1.2.17</log4j.version>
 		<logback.version>1.0.6</logback.version>
@@ -70,7 +70,7 @@
 		<aws-s3-manager.version>1.2.3</aws-s3-manager.version>
 		<api-tools.version>1.0.5</api-tools.version>
 		<monte-repack.version>1.0</monte-repack.version>
-		
+
 	</properties>
 
 	<repositories>
@@ -386,21 +386,28 @@
 			<artifactId>aws-s3-manager</artifactId>
 			<version>${aws-s3-manager.version}</version>
 		</dependency>
-		
+
 		<!-- api-tools -->
 		<dependency>
 			<groupId>com.qaprosoft</groupId>
 			<artifactId>api-tools</artifactId>
 			<version>${api-tools.version}</version>
 		</dependency>
-		
-		<!-- monte-repack video recording  -->
-	    <dependency>
+
+		<!-- monte-repack video recording -->
+		<dependency>
 			<groupId>com.pojosontheweb</groupId>
 			<artifactId>monte-repack</artifactId>
 			<version>${monte-repack.version}</version>
- 	    </dependency>
-		
+		</dependency>
+
+		<dependency>
+			<groupId>org.robotframework</groupId>
+			<artifactId>javalib-core</artifactId>
+			<version>1.2.1</version>
+		</dependency>
+
+
 	</dependencies>
 
 	<distributionManagement>

--- a/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
+++ b/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
@@ -119,6 +119,8 @@ public class Configuration
 
 		AUTO_SCREENSHOT("auto_screenshot"),
 		
+		MAKE_ROBOSCREENSHOTS("make_roboscreenshots"),
+		
 		IMPLICIT_TIMEOUT("implicit_timeout"),
 
 		EXPLICIT_TIMEOUT("explicit_timeout"),


### PR DESCRIPTION
The changes allow making screenshots of alert messages opened as well as desktop screenshots, when windows has disappeared (for example: after button click).
Tested only on Modius project (successfully).
Not tested on mobile devices, neither on platforms other than Windows.
