### PR TITLE
Fixed IllegalStateException - No Match Found Issue

### DIFF
--- a/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/locator/LocalizedAnnotations.java
+++ b/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/locator/LocalizedAnnotations.java
@@ -30,8 +30,6 @@ public class LocalizedAnnotations extends Annotations
 {
 	private static Pattern L10N_PATTERN = Pattern.compile(SpecialKeywords.L10N_PATTERN);
 	
-	private static Matcher matcher;
-
 	public LocalizedAnnotations(Field field)
 	{
 		super(field);
@@ -44,7 +42,7 @@ public class LocalizedAnnotations extends Annotations
 		By by = super.buildBy();
 		String param = by.toString();
 		//replace by using localization pattern
-		matcher = L10N_PATTERN.matcher(param);
+		Matcher matcher = L10N_PATTERN.matcher(param);
 		if (matcher.find())
 		{
 			int start = param.indexOf(SpecialKeywords.L10N+ ":") + 5;


### PR DESCRIPTION
An intermittent issue was occurring when running tests in parallel. The method call `matcher.group()` was throwing IllegalStateException with the message "No match found".

I was able to resolve this by removing the static class variable `matcher` and adding the declaration in the `buildBy` method.

I also tried changing the class variable to `private static ThreadLocal<Matcher> matcher = new ThreadLocal<Matcher>();` which also worked. I decided to use the implementation in this pull request though since I did not see any reason to use a class variable because all references to `matcher` were contained in the `buildBy` method.