### PR TITLE
build-snapshot: Moving from BrowserMobProxy to BrowserUpProxy

### DIFF
--- a/archetype/src/main/resources/archetype-resources/src/test/java/carina/demo/ProxySampleTest.java
+++ b/archetype/src/main/resources/archetype-resources/src/test/java/carina/demo/ProxySampleTest.java
@@ -52,7 +52,7 @@ public class ProxySampleTest implements IAbstractTest {
     @BeforeMethod(alwaysRun = true)
     public void startProxy()
     {
-        R.CONFIG.put("browsermob_proxy", "true");
+        R.CONFIG.put("browserup_proxy", "true");
         getDriver();
         proxy = ProxyPool.getProxy();
         proxy.enableHarCaptureTypes(CaptureType.REQUEST_CONTENT, CaptureType.RESPONSE_CONTENT);

--- a/carina-core/src/main/resources/config.properties
+++ b/carina-core/src/main/resources/config.properties
@@ -18,13 +18,13 @@ proxy_host=NULL
 proxy_port=NULL
 proxy_protocols=http,https,ftp
 proxy_set_to_system=NULL
-browsermob_proxy=NULL
+browserup_proxy=NULL
 no_proxy=NULL
-# disabled below property to make SSL support for browsermob proxy automatically.
-browsermob_disabled_mitm=NULL
+# disabled below property to make SSL support for browserup proxy automatically.
+browserup_disabled_mitm=NULL
 #0 - dynamic port
-browsermob_port=0
-browsermob_ports_range=NULL
+browserup_port=0
+browserup_ports_range=NULL
 
 # browser options and arguments
 chrome_args=NULL

--- a/carina-proxy/pom.xml
+++ b/carina-proxy/pom.xml
@@ -7,8 +7,8 @@
 	<artifactId>carina-proxy</artifactId>
 	<packaging>jar</packaging>
 
-	<name>BrowserMobProxy Core</name>
-	<description>BrowserMob Proxy module web, mobile, API testing.</description>
+	<name>BrowserUpProxy Core</name>
+	<description>BrowserUp Proxy module web, mobile, API testing.</description>
 
 	<parent>
 		<groupId>com.qaprosoft</groupId>
@@ -40,9 +40,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>net.lightbody.bmp</groupId>
-			<artifactId>browsermob-core</artifactId>
-			<version>2.1.5</version>
+			<groupId>com.browserup</groupId>
+			<artifactId>browserup-proxy-core</artifactId>
+			<version>2.1.2</version>
 		</dependency>
 
 		<dependency>

--- a/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
+++ b/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/ProxyPool.java
@@ -33,8 +33,8 @@ import com.qaprosoft.carina.core.foundation.utils.R;
 import com.qaprosoft.carina.core.foundation.utils.android.recorder.utils.AdbExecutor;
 import com.qaprosoft.carina.core.foundation.utils.common.CommonUtils;
 
-import net.lightbody.bmp.BrowserMobProxy;
-import net.lightbody.bmp.BrowserMobProxyServer;
+import com.browserup.bup.BrowserUpProxy;
+import com.browserup.bup.BrowserUpProxyServer;
 
 public final class ProxyPool {
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -51,45 +51,45 @@ public final class ProxyPool {
 	}
 	
 	public static void initProxyPortsRange() {
-		if (!Configuration.get(Parameter.BROWSERMOB_PORTS_RANGE).isEmpty()) {
+		if (!Configuration.get(Parameter.BROWSERUP_PORTS_RANGE).isEmpty()) {
 			try {
-				String[] ports = Configuration.get(Parameter.BROWSERMOB_PORTS_RANGE).split(":");
+				String[] ports = Configuration.get(Parameter.BROWSERUP_PORTS_RANGE).split(":");
 				for (int i = Integer.valueOf(ports[0]); i <= Integer.valueOf(ports[1]); i++) {
 					proxyPortsFromRange.put(i, true);
 				}
 			} catch (Exception e) {
-				throw new RuntimeException("Please specify BROWSERMOB_PORTS_RANGE in format 'port_from:port_to'");
+				throw new RuntimeException("Please specify BROWSERUP_PORTS_RANGE in format 'port_from:port_to'");
 			}
 		}
 	}
     
-    // ------------------------- BOWSERMOB PROXY ---------------------
+    // ------------------------- BOWSERUP PROXY ---------------------
     // TODO: investigate possibility to return interface to support JettyProxy
     /**
-     * create BrowserMobProxy Server object
-     * @return BrowserMobProxy
+     * create BrowserUpProxy Server object
+     * @return BrowserUpProxy
      * 
      */
-    public static BrowserMobProxy createProxy() {
-        BrowserMobProxyServer proxy = new BrowserMobProxyServer();
+    public static BrowserUpProxy createProxy() {
+        BrowserUpProxyServer proxy = new BrowserUpProxyServer();
         proxy.setTrustAllServers(true);
         //System.setProperty("jsse.enableSNIExtension", "false");
         
         // disable MITM in case we do not need it
-        proxy.setMitmDisabled(Configuration.getBoolean(Parameter.BROWSERMOB_MITM));
+        proxy.setMitmDisabled(Configuration.getBoolean(Parameter.BROWSERUP_MITM));
         
         return proxy;
     }
     
-    public static void setupBrowserMobProxy()
+    public static void setupBrowserUpProxy()
     {
-        if (Configuration.getBoolean(Parameter.BROWSERMOB_PROXY)) {
+        if (Configuration.getBoolean(Parameter.BROWSERUP_PROXY)) {
             long threadId = Thread.currentThread().getId();
-            BrowserMobProxy proxy = startProxy();
+            BrowserUpProxy proxy = startProxy();
 
             Integer port = proxy.getPort();
             proxyPortsByThread.put(threadId, port);
-            
+
             // reuse "proxy_host" to be able to share valid publicly available host. 
             // it is useful when java and web tests are executed absolutely in different containers/networks. 
             if (Configuration.get(Parameter.PROXY_HOST).isEmpty()) {
@@ -97,9 +97,9 @@ public final class ProxyPool {
             	R.CONFIG.put(Parameter.PROXY_HOST.getKey(), currentIP);
             }
             
-            LOGGER.warn("Set http/https proxy settings only to use with BrowserMobProxy host: " + Configuration.get(Parameter.PROXY_HOST) + "; port: "
+            LOGGER.warn("Set http/https proxy settings only to use with BrowserUpProxy host: " + Configuration.get(Parameter.PROXY_HOST) + "; port: "
                     + proxyPortsByThread.get(threadId));
-            
+
             R.CONFIG.put(Parameter.PROXY_PORT.getKey(), port.toString());
             
             R.CONFIG.put("proxy_protocols", "http,https");
@@ -111,12 +111,12 @@ public final class ProxyPool {
         }
     }
 
-    // https://github.com/lightbody/browsermob-proxy/issues/264 'started' flag is not set to false after stopping BrowserMobProxyServer
-    // Due to the above issue we can't control BrowserMob isRunning state and shouldn't stop it
+    // https://github.com/lightbody/browsermob-proxy/issues/264 'started' flag is not set to false after stopping BrowserUpProxyServer
+    // Due to the above issue we can't control BrowserUp isRunning state and shouldn't stop it
     // TODO: investigate possibility to clean HAR files if necessary
     
     /**
-     * stop BrowserMobProxy Server
+     * stop BrowserUpProxy Server
      * 
      */
     /*
@@ -125,15 +125,15 @@ public final class ProxyPool {
 
         LOGGER.debug("stopProxy starting...");
         if (proxies.containsKey(threadId)) {
-            BrowserMobProxy proxy = proxies.get(threadId);
+            BrowserUpProxy proxy = proxies.get(threadId);
             if (proxy != null) {
                 LOGGER.debug("Found registered proxy by thread: " + threadId);
 
                 if (proxy.isStarted()) {
-                    LOGGER.info("Stopping BrowserMob proxy...");
+                    LOGGER.info("Stopping BrowserUp proxy...");
                     proxy.stop();
                 } else {
-                    LOGGER.info("Stopping BrowserMob proxy skipped as it is not started.");
+                    LOGGER.info("Stopping BrowserUp proxy skipped as it is not started.");
                 }
             }
             proxies.remove(threadId);
@@ -141,52 +141,52 @@ public final class ProxyPool {
         LOGGER.debug("stopProxy finished...");
     }*/
     
-    // ------------------------- BOWSERMOB PROXY ---------------------
+    // ------------------------- BOWSERUP PROXY ---------------------
     
-    private static final ConcurrentHashMap<Long, BrowserMobProxy> proxies = new ConcurrentHashMap<Long, BrowserMobProxy>();
+    private static final ConcurrentHashMap<Long, BrowserUpProxy> proxies = new ConcurrentHashMap<Long, BrowserUpProxy>();
     
     /**
-     * Checking whether BROWSERMOB_PORT is declared. then it will be used as port for browsermob proxy
-     * Otherwise first available port from BROWSERMOB_PORTS_RANGE will be used
+     * Checking whether BROWSERUP_PORT is declared. then it will be used as port for browserup proxy
+     * Otherwise first available port from BROWSERUP_PORTS_RANGE will be used
      * 
      * @return port
      */
 	public static int getProxyPortFromConfig() {
-		if (!Configuration.get(Parameter.BROWSERMOB_PORT).isEmpty())
-			return Configuration.getInt(Parameter.BROWSERMOB_PORT);
-		else if (!Configuration.get(Parameter.BROWSERMOB_PORTS_RANGE).isEmpty()) {
+		if (!Configuration.get(Parameter.BROWSERUP_PORT).isEmpty())
+			return Configuration.getInt(Parameter.BROWSERUP_PORT);
+		else if (!Configuration.get(Parameter.BROWSERUP_PORTS_RANGE).isEmpty()) {
 			for (Map.Entry<Integer, Boolean> pair : proxyPortsFromRange.entrySet()) {
 				if (pair.getValue()) {
-					LOGGER.info("Making BrowserMob proxy port busy: " + pair.getKey());
+					LOGGER.info("Making BrowserUp proxy port busy: " + pair.getKey());
 					pair.setValue(false);
 					return pair.getKey().intValue();
 				}
 			}
 			throw new RuntimeException(
-					"All ports from Parameter.BROWSERMOB_PORTS_RANGE are currently busy. Please change execution thread count");
+					"All ports from Parameter.BROWSERUP_PORTS_RANGE are currently busy. Please change execution thread count");
 		}
 		throw new RuntimeException(
-				"Neither Parameter.BROWSERMOB_PORT nor Parameter.BROWSERMOB_PORTS_RANGE are specified!");
+				"Neither Parameter.BROWSERUP_PORT nor Parameter.BROWSERUP_PORTS_RANGE are specified!");
 	}
 
     // TODO: investigate possibility to return interface to support JettyProxy
     /**
-     * start BrowserMobProxy Server
+     * start BrowserUpProxy Server
      * 
-     * @return BrowserMobProxy
+     * @return BrowserUp Proxy
      * 
      */
-    public static synchronized BrowserMobProxy startProxy() {
+    public static synchronized BrowserUpProxy startProxy() {
         return startProxy(getProxyPortFromConfig());
     }
     
-    public static synchronized BrowserMobProxy startProxy(int proxyPort) {
-        if (!Configuration.getBoolean(Parameter.BROWSERMOB_PROXY)) {
+    public static synchronized BrowserUpProxy startProxy(int proxyPort) {
+        if (!Configuration.getBoolean(Parameter.BROWSERUP_PROXY)) {
             LOGGER.debug("Proxy is disabled.");
             return null;
         }
-        // integrate browserMob proxy if required here
-        BrowserMobProxy proxy = null;
+        // integrate browserup proxy if required here
+        BrowserUpProxy proxy = null;
         long threadId = Thread.currentThread().getId();
         if (proxies.containsKey(threadId)) {
             proxy = proxies.get(threadId);
@@ -203,12 +203,12 @@ public final class ProxyPool {
         }
         
         if (!proxy.isStarted()) {
-            LOGGER.info("Starting BrowserMob proxy...");
+            LOGGER.info("Starting BrowserUp proxy...");
         	// TODO: [VD] confirmed with MB that restart was added just in case. Maybe comment/remove?
             killProcessByPort(proxyPort);
             proxy.start(proxyPort);
         } else {
-            LOGGER.info("BrowserMob proxy is already started on port " + proxy.getPort());
+            LOGGER.info("BrowserUp proxy is already started on port " + proxy.getPort());
         }
 
         return proxy;
@@ -217,19 +217,19 @@ public final class ProxyPool {
     private static void setProxyPortToAvailable(long threadId) {
 		if (proxyPortsByThread.get(threadId) != null) {
 			if (proxyPortsFromRange.get(proxyPortsByThread.get(threadId)) != null) {
-				LOGGER.info("Setting BrowserMob proxy port " + proxyPortsByThread.get(threadId) + " to available state");
+				LOGGER.info("Setting BrowserUp proxy port " + proxyPortsByThread.get(threadId) + " to available state");
 				proxyPortsFromRange.put(proxyPortsByThread.get(threadId), true);
 				proxyPortsByThread.remove(threadId);
 			}
 		}
     }
 
-    // https://github.com/lightbody/browsermob-proxy/issues/264 'started' flag is not set to false after stopping BrowserMobProxyServer
+    // https://github.com/lightbody/browsermob-proxy/issues/264 'started' flag is not set to false after stopping BrowserUpProxyServer
     // Due to the above issue we can't control BrowserMob isRunning state and shouldn't stop it
     // TODO: investigate possibility to clean HAR files if necessary
     
     /**
-     * stop BrowserMobProxy Server
+     * stop BrowserUpProxy Server
      * 
      */
     public static void stopProxy() {
@@ -252,7 +252,7 @@ public final class ProxyPool {
     private static void stopProxyByThread(long threadId) {
         if (proxies.containsKey(threadId)) {
             setProxyPortToAvailable(threadId);
-            BrowserMobProxy proxy = proxies.get(threadId);
+            BrowserUpProxy proxy = proxies.get(threadId);
             if (proxy != null) {
                 LOGGER.debug("Found registered proxy by thread: " + threadId);
 
@@ -274,18 +274,18 @@ public final class ProxyPool {
     }
 
     /**
-     * get registered BrowserMobProxy Server
+     * get registered BrowserUpProxy Server
      * 
-     * @return BrowserMobProxy
+     * @return BrowserUpProxy
      * 
      */
-    public static BrowserMobProxy getProxy() {
-        BrowserMobProxy proxy = null;
+    public static BrowserUpProxy getProxy() {
+        BrowserUpProxy proxy = null;
         long threadId = Thread.currentThread().getId();
         if (proxies.containsKey(threadId)) {
             proxy = proxies.get(threadId);
         } else {
-            Assert.fail("There is not a registered BrowserMobProxy for thread: " + threadId);
+            Assert.fail("There is not a registered BrowserUpProxy for thread: " + threadId);
         }
         return proxy;
     }
@@ -296,7 +296,7 @@ public final class ProxyPool {
         if (proxyPortsByThread.containsKey(threadId)) {
             port = proxyPortsByThread.get(threadId);
         } else {
-            Assert.fail("This is not a register BrowserMobProxy Port for thread: " + threadId);
+            Assert.fail("This is not a register BrowserUpProxy Port for thread: " + threadId);
         }
         return port;
     }
@@ -313,13 +313,13 @@ public final class ProxyPool {
     }
 
     /**
-     * register custom BrowserMobProxy Server
+     * register custom BrowserUpProxy Server
      * 
      * @param proxy
-     *            custom BrowserMobProxy
+     *            custom BrowserUpProxy
      * 
      */
-    public static void registerProxy(BrowserMobProxy proxy) {
+    public static void registerProxy(BrowserUpProxy proxy) {
         long threadId = Thread.currentThread().getId();
         if (proxies.containsKey(threadId)) {
             LOGGER.warn("Existing proxy is detected and will be overrwitten");
@@ -342,7 +342,7 @@ public final class ProxyPool {
      */
     private static void killProcessByPort(int port) {
         if (port == 0) {
-            //do nothing as it is default dynamic browsermob proxy
+            //do nothing as it is default dynamic browserup proxy
             return;
         }
         LOGGER.info(String.format("Process on port %d will be closed.", port));

--- a/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/rewrite/CustomRqFilter.java
+++ b/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/rewrite/CustomRqFilter.java
@@ -24,9 +24,9 @@ import org.slf4j.LoggerFactory;
 
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
-import net.lightbody.bmp.filters.RequestFilter;
-import net.lightbody.bmp.util.HttpMessageContents;
-import net.lightbody.bmp.util.HttpMessageInfo;
+import com.browserup.bup.filters.RequestFilter;
+import com.browserup.bup.util.HttpMessageContents;
+import com.browserup.bup.util.HttpMessageInfo;
 
 /**
  * Class wrapper for RequestFilter. Rewrite rules can be configured as separate

--- a/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/rewrite/CustomRsFilter.java
+++ b/carina-proxy/src/main/java/com/qaprosoft/carina/browsermobproxy/rewrite/CustomRsFilter.java
@@ -23,9 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.netty.handler.codec.http.HttpResponse;
-import net.lightbody.bmp.filters.ResponseFilter;
-import net.lightbody.bmp.util.HttpMessageContents;
-import net.lightbody.bmp.util.HttpMessageInfo;
+import com.browserup.bup.filters.ResponseFilter;
+import com.browserup.bup.util.HttpMessageContents;
+import com.browserup.bup.util.HttpMessageInfo;
 
 /**
  * Class wrapper for ResponseFilter. Rewrite rules can be configured as separate

--- a/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserUpPortsRangeTest.java
+++ b/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserUpPortsRangeTest.java
@@ -23,20 +23,20 @@ import org.testng.annotations.Test;
 import com.qaprosoft.carina.core.foundation.utils.R;
 import com.qaprosoft.carina.proxy.SystemProxy;
 
-import net.lightbody.bmp.BrowserMobProxy;
+import com.browserup.bup.BrowserUpProxy;
 
-public class BrowserMobPortsRangeTest {
+public class BrowserUpPortsRangeTest {
     private static String header = "my_header";
     private static String headerValue = "my_value";
 
     @BeforeClass(alwaysRun = true)
     public void beforeClass() {
         R.CONFIG.put("core_log_level", "DEBUG");
-        R.CONFIG.put("browsermob_proxy", "true");
+        R.CONFIG.put("browserup_proxy", "true");
         R.CONFIG.put("proxy_set_to_system", "false");
-        R.CONFIG.put("browsermob_port", "NULL");
-        R.CONFIG.put("browsermob_ports_range", "0:0");
-        R.CONFIG.put("browsermob_disabled_mitm", "false");
+        R.CONFIG.put("browserup_port", "NULL");
+        R.CONFIG.put("browserup_ports_range", "0:0");
+        R.CONFIG.put("browserup_disabled_mitm", "false");
     }
 
     @AfterMethod(alwaysRun = true)
@@ -47,15 +47,15 @@ public class BrowserMobPortsRangeTest {
     @Test
     public void testPortsRange() {
         initialize();
-        Assert.assertTrue(ProxyPool.getProxy().isStarted(), "BrowserMobProxy is not started!");
+        Assert.assertTrue(ProxyPool.getProxy().isStarted(), "BrowserUpProxy is not started!");
     }
 
     private void initialize() {
     	ProxyPool.initProxyPortsRange();
-        ProxyPool.setupBrowserMobProxy();
+        ProxyPool.setupBrowserUpProxy();
         SystemProxy.setupProxy();
 
-        BrowserMobProxy proxy = ProxyPool.getProxy();
+        BrowserUpProxy proxy = ProxyPool.getProxy();
         proxy.addHeader(header, headerValue);
     }
 

--- a/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserUpTest.java
+++ b/carina-proxy/src/test/java/com/qaprosoft/carina/browsermobproxy/BrowserUpTest.java
@@ -38,10 +38,10 @@ import com.qaprosoft.carina.core.foundation.utils.Configuration.Parameter;
 import com.qaprosoft.carina.core.foundation.utils.R;
 import com.qaprosoft.carina.proxy.SystemProxy;
 
-import net.lightbody.bmp.BrowserMobProxy;
-import net.lightbody.bmp.proxy.CaptureType;
+import com.browserup.bup.BrowserUpProxy;
+import com.browserup.bup.proxy.CaptureType;
 
-public class BrowserMobTest {
+public class BrowserUpTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static String header = "my_header";
     private static String headerValue = "my_value";
@@ -52,10 +52,10 @@ public class BrowserMobTest {
     @BeforeClass(alwaysRun = true)
     public void beforeClass() {
         R.CONFIG.put("core_log_level", "DEBUG");
-        R.CONFIG.put("browsermob_proxy", "true");
-        R.CONFIG.put("browsermob_port", "0");
+        R.CONFIG.put("browserup_proxy", "true");
+        R.CONFIG.put("browserup_port", "0");
         R.CONFIG.put("proxy_set_to_system", "true");
-        R.CONFIG.put("browsermob_disabled_mitm", "false");
+        R.CONFIG.put("browserup_disabled_mitm", "false");
     }
 
     @AfterMethod(alwaysRun = true)
@@ -64,20 +64,20 @@ public class BrowserMobTest {
     }
 
     @Test
-    public void testIsBrowserModStarted() {
+    public void testIsBrowserUpStarted() {
         initialize();
-        Assert.assertTrue(ProxyPool.getProxy().isStarted(), "BrowserMobProxy is not started!");
+        Assert.assertTrue(ProxyPool.getProxy().isStarted(), "BrowserUpProxy is not started!");
     }
 
     @Test
-    public void testBrowserModProxySystemIntegration() {
+    public void testBrowserUpProxySystemIntegration() {
         initialize();
         Assert.assertEquals(Configuration.get(Parameter.PROXY_HOST), System.getProperty("http.proxyHost"));
         Assert.assertEquals(Configuration.get(Parameter.PROXY_PORT), System.getProperty("http.proxyPort"));
     }
 
     @Test
-    public void testBrowserModProxyHeader() {
+    public void testBrowserUpProxyHeader() {
         initialize();
         Map<String, String> headers = ProxyPool.getProxy().getAllHeaders();
         Assert.assertTrue(headers.containsKey(header), "There is no custom header: " + header);
@@ -90,8 +90,8 @@ public class BrowserMobTest {
     }
 
     @Test
-    public void testBrowserModProxyRegisteration() {
-        BrowserMobProxy proxy = ProxyPool.startProxy();
+    public void testBrowserUpProxyRegisteration() {
+        BrowserUpProxy proxy = ProxyPool.startProxy();
         ProxyPool.registerProxy(proxy);
         Assert.assertTrue(ProxyPool.isProxyRegistered(), "Proxy wasn't registered in ProxyPool!");
         ProxyPool.stopAllProxies();
@@ -105,9 +105,9 @@ public class BrowserMobTest {
         SSLContext sslContext = localTrustStoreBuilder.createSSLContext();
         SSLContext.setDefault(sslContext);
 
-        ProxyPool.setupBrowserMobProxy();
+        ProxyPool.setupBrowserUpProxy();
         SystemProxy.setupProxy();
-        BrowserMobProxy proxy = ProxyPool.getProxy();
+        BrowserUpProxy proxy = ProxyPool.getProxy();
         proxy.enableHarCaptureTypes(CaptureType.RESPONSE_CONTENT);
         proxy.newHar();
 
@@ -134,10 +134,10 @@ public class BrowserMobTest {
 
     @Test(dataProvider = "dataProviderForMultiThreadProxy")
     public void testRegisterProxy(String arg) {
-        ProxyPool.setupBrowserMobProxy();
+        ProxyPool.setupBrowserUpProxy();
         int tempPort = ProxyPool.getProxy().getPort();
         ProxyPool.stopProxy();
-        BrowserMobProxy proxy = ProxyPool.createProxy();
+        BrowserUpProxy proxy = ProxyPool.createProxy();
         proxy.setTrustAllServers(true);
         proxy.setMitmDisabled(false);
         ProxyPool.registerProxy(proxy);
@@ -149,10 +149,10 @@ public class BrowserMobTest {
     }
 
     private void initialize() {
-        ProxyPool.setupBrowserMobProxy();
+        ProxyPool.setupBrowserUpProxy();
         SystemProxy.setupProxy();
 
-        BrowserMobProxy proxy = ProxyPool.getProxy();
+        BrowserUpProxy proxy = ProxyPool.getProxy();
         proxy.addHeader(header, headerValue);
     }
 

--- a/carina-proxy/src/test/java/com/qaprosoft/carina/proxy/SystemProxyTest.java
+++ b/carina-proxy/src/test/java/com/qaprosoft/carina/proxy/SystemProxyTest.java
@@ -31,11 +31,10 @@ public class SystemProxyTest {
     public void beforeClass() {
         // do nothing
 
-        R.CONFIG.put("browsermob_proxy", "false");
+        R.CONFIG.put("browserup_proxy", "false");
         R.CONFIG.put("proxy_set_to_system", "true");
         R.CONFIG.put("proxy_host", host);
         R.CONFIG.put(Parameter.PROXY_PORT.getKey(), port);
-
     }
 
     @BeforeMethod

--- a/carina-proxy/src/test/resources/config.properties
+++ b/carina-proxy/src/test/resources/config.properties
@@ -1,5 +1,5 @@
-browsermob_proxy=true
-browsermob_port=0
-browsermob_ports_range=NULL
+browserup_proxy=true
+browserup_port=0
+browserup_ports_range=NULL
 proxy_set_to_system=true
-browsermob_disabled_mitm=false
+browserup_disabled_mitm=false

--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/utils/Configuration.java
@@ -86,13 +86,13 @@ public class Configuration {
         
         NO_PROXY("no_proxy"),
 
-        BROWSERMOB_PROXY("browsermob_proxy"),
+        BROWSERUP_PROXY("browserup_proxy"),
 
-        BROWSERMOB_PORT("browsermob_port"),
+        BROWSERUP_PORT("browserup_port"),
 
-        BROWSERMOB_PORTS_RANGE("browsermob_ports_range"),
+        BROWSERUP_PORTS_RANGE("browserup_ports_range"),
 
-        BROWSERMOB_MITM("browsermob_disabled_mitm"),
+        BROWSERUP_MITM("browserup_disabled_mitm"),
 
         PROXY_SET_TO_SYSTEM("proxy_set_to_system"),
 

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/IDriverPool.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/IDriverPool.java
@@ -388,9 +388,9 @@ public interface IDriverPool {
                     // the test thread
                     device = getDefaultDevice();
                 }
-                
+
                 // moved proxy start logic here since device will be initialized here only
-                if (Configuration.getBoolean(Parameter.BROWSERMOB_PROXY)) {
+                if (Configuration.getBoolean(Parameter.BROWSERUP_PROXY)) {
                     if (!device.isNull()) {
                     	int proxyPort;
                         try {
@@ -405,7 +405,6 @@ public interface IDriverPool {
                     }
                 }
 
-                
                 // new 6.0 approach to manipulate drivers via regular Set
                 CarinaDriver carinaDriver = new CarinaDriver(name, drv, device, TestPhase.getActivePhase(), threadId);
                 driversPool.add(carinaDriver);

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/AbstractCapabilities.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/core/capability/AbstractCapabilities.java
@@ -120,14 +120,14 @@ public abstract class AbstractCapabilities {
     }
 
     protected Proxy setupProxy() {
-        ProxyPool.setupBrowserMobProxy();
+        ProxyPool.setupBrowserUpProxy();
         SystemProxy.setupProxy();
 
         String proxyHost = Configuration.get(Parameter.PROXY_HOST);
         String proxyPort = Configuration.get(Parameter.PROXY_PORT);
         String noProxy = Configuration.get(Parameter.NO_PROXY);
         
-        if (Configuration.get(Parameter.BROWSERMOB_PROXY).equals("true")) {
+        if (Configuration.get(Parameter.BROWSERUP_PROXY).equals("true")) {
             proxyPort = Integer.toString(ProxyPool.getProxyPortFromThread());
         }
         List<String> protocols = Arrays.asList(Configuration.get(Parameter.PROXY_PROTOCOLS).split("[\\s,]+"));

--- a/carina-webdriver/src/test/resources/config.properties
+++ b/carina-webdriver/src/test/resources/config.properties
@@ -14,13 +14,13 @@ proxy_host=NULL
 proxy_port=NULL
 proxy_protocols=http,https,ftp
 proxy_set_to_system=NULL
-browsermob_proxy=NULL
+browserup_proxy=NULL
 no_proxy=NULL
-# disabled below property to make SSL support for browsermob proxy automatically.
-browsermob_disabled_mitm=NULL
+# disabled below property to make SSL support for browserup proxy automatically.
+browserup_disabled_mitm=NULL
 #0 - dynamic port
-browsermob_port=0
-browsermob_ports_range=NULL
+browserup_port=0
+browserup_ports_range=NULL
 
 # capabilities for browser
 capabilities.takesScreenshot=false

--- a/docs/advanced/proxy.md
+++ b/docs/advanced/proxy.md
@@ -1,40 +1,42 @@
+
 # Proxy usage
-There is a possibility to send all test traffic via proxy including the embedded light-weight BrowserMob proxy server.
+There is a possibility to send all test traffic via proxy including the embedded light-weight BrowserUp proxy server.
+
 There are several properties available to manage all kinds of proxy usage:
 ```
 proxy_host=NULL
 proxy_port=NULL
 proxy_protocols=http,https,ftp
 proxy_set_to_system=true
-browsermob_proxy=false
-browsermob_disabled_mitm=false
-browsermob_port=0
+browserup_proxy=false
+browserup_disabled_mitm=false
+browserup_port=0
 ```
 Declare proxy_host, proxy_port and proxy_protocols to send all Web and API test traffic via your static network proxy.
 Also, to enable proxy for TestNG Java process, **proxy_set_to_system** must be specifed to **true**, otherwise only WebDrivers and API clients will be proxied.
 
 Note: The above settings are mostly required to get public internet access through corporate proxies.
 
-## Raising inbuilt proxy-server (BrowserMob)
-Also, Carina can start an embedded proxy to proxy/view/filter requests/responses. There is an inbuilt library BrowserMobProxy in Carina-proxy module. Below you can find BrowserMob proxy related parameters in your **config.properties** file:
+## Raising inbuilt proxy-server (BrowserUp)
+Also, Carina can start an embedded proxy to proxy/view/filter requests/responses. There is an inbuilt library BrowserUpProxy in Carina-proxy module. Below you can find BrowserUp proxy related parameters in your **config.properties** file:
 ```
-browsermob_proxy=true
-browsermob_disabled_mitm=false
-browsermob_port=0
-browsermob_ports_range=NULL
+browserup_proxy=true
+browserup_disabled_mitm=false
+browserup_port=0
+browserup_ports_range=NULL
 ```
-With the enabled **browsermob_proxy**, Carina will start the dedicated proxy instance on every test method. 
+With the enabled **browserup_proxy**, Carina will start the dedicated proxy instance on every test method. 
 
-Carina automatically detects an IP address for your local browsermob proxy and puts it into the capabilities in case if **proxy_host=NULL**. If you want to map some publicly available IP address for your browsermob proxy instance then you'll need to override it via **proxy_host** property.
+Carina automatically detects an IP address for your local browserup proxy and puts it into the capabilities in case if **proxy_host=NULL**. If you want to map some publicly available IP address for your browserup proxy instance then you'll need to override it via **proxy_host** property.
 E.g. **proxy_host=myhostname** is useful in case of running maven process inside a docker container. Override the hostname, and it will be available from Selenium instance.
 
-**browsermob_port=0** means that Carina dynamically identifies a free port for a proxy session.
+**browserup_port=0** means that Carina dynamically identifies a free port for a proxy session.
 
-**browsermob_ports_range=8001:8003** means that Carina will use only ports from given range for starting of browsermob sessions. That's reasonable for cases when only several ports are shared at environment and can be accessed from other machines within the network. If all ports are used then test will wait for the first freed port.
+**browserup_ports_range=8001:8003** means that Carina will use only ports from given range for starting of browserup sessions. That's reasonable for cases when only several ports are shared at environment and can be accessed from other machines within the network. If all ports are used then test will wait for the first freed port.
 
-**browsermob_disabled_mitm** is disabled by default. 
+**browserup_disabled_mitm** is disabled by default. 
 
-**Important!** If you have troubles with  SSL traffic sniffing, the first thing you should do is to change **browsermob_disabled_mitm** property value!
+**Important!** If you have troubles with  SSL traffic sniffing, the first thing you should do is to change **browserup_disabled_mitm** property value!
 
 ### Using proxy-server in Java code:
 
@@ -44,7 +46,7 @@ getDriver();
 ```
 Note: During the driver startup, Carina automatically starts proxy and adjusts browser capabilities to track the desired protocols. To get proxy instance for the current test/thread, you can call:
 ```
-BrowserMobProxy proxy = ProxyPool.getProxy();
+BrowserUpProxy proxy = ProxyPool.getProxy();
 ```
 2. Enable the required Har capture type using:
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,18 +130,18 @@ All the project configuration properties are located in a **_config.properties**
 		<td>http, https, ftp, socks</td>
 	</tr>
 		<tr>
-		<td>browsermob_proxy</td>
-		<td>Boolean parameter which enables or disables the automatic BrowserMob proxy launch</td>
+		<td>browserup_proxy</td>
+		<td>Boolean parameter which enables or disables the automatic BrowserUp proxy launch</td>
 		<td>true, false</td>
 	</tr>
 		<tr>
-		<td>browsermob_port</td>
-		<td>Port number for BrowserMob proxy (if nothing or 0 specified, then any free port will be reused)</td>
+		<td>browserup_port</td>
+		<td>Port number for BrowserUp proxy (if nothing or 0 specified, then any free port will be reused)</td>
 		<td>Integer</td>
 	</tr>
 		<tr>
-		<td>browsermob_ports_range</td>
-		<td>Range of ports that will be used for starting of browsermob proxy. First available port from the range will be used. If all ports are used then test will wait for the first freed port.</td>
+		<td>browserup_ports_range</td>
+		<td>Range of ports that will be used for starting of browserup proxy. First available port from the range will be used. If all ports are used then test will wait for the first freed port.</td>
 		<td>8001:8003</td>
 	</tr>
 		<tr>


### PR DESCRIPTION
This Pull Request swaps out the prior BrowserMobProxy library that we were utilizing and moves over to BrowserUpProxy which can be called the successor to BrowserMobProxy, as the former hasn't been updated in a few years.

There may be 1-2 more commits to this after snapshot testing has concluded.

