### PR TITLE
testng.version 7.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <!-- Testings -->
-        <testng.version>7.3.0</testng.version>
+        <testng.version>7.4.0</testng.version>
         <testng-foundation.version>2.0.1</testng-foundation.version>
         <!-- Logging -->
         <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
Updating testng to version 7.4.0 which contains resolution for some known testng bugs.
In particular it has fix for https://github.com/cbeust/testng/issues/188 "GITHUB-188: suite parallel="methods" does not work when there are multiple <test> tags in the testng.xml"
In new testng you can use "parallel=methods" with argument "-Dtestng.strict.parallel=true" to enable parallel threads for each independent test method ignoring <test> tags placement