### PR TITLE
make testDirectory InheritableThreadLocal variable

### DIFF
--- a/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
+++ b/carina-utils/src/main/java/com/qaprosoft/carina/core/foundation/report/ReportContext.java
@@ -92,7 +92,7 @@ public class ReportContext {
 
     private static long rootID;
 
-    private static final ThreadLocal<File> testDirectory = new ThreadLocal<File>();
+    private static final ThreadLocal<File> testDirectory = new InheritableThreadLocal<>();
     private static final ThreadLocal<Boolean> isCustomTestDirName = new ThreadLocal<Boolean>();
 
     private static final ExecutorService executor = Executors.newCachedThreadPool();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes #1488 
This solution works only for child threads. If we enable DEBUG logging level for test, we'll got one extra directory for line [2021-11-03 06:33:56] [CarinaListener.java] [14] [DEBUG] Running shutdown hook

Tested only for web and api

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
