### PR TITLE
fixed bug of splitting for methodPath url inside init method

### DIFF
--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethod.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethod.java
@@ -100,7 +100,8 @@ public abstract class AbstractApiMethod extends HttpClient {
         }
         if (typePath.contains(":")) {
             methodType = HttpMethodType.valueOf(typePath.split(":")[0]);
-            methodPath = typePath.split(":")[1];
+            methodPath = typePath.split(methodType + ":")[1];
+
         } else {
             methodType = HttpMethodType.valueOf(typePath);
         }

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethod.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethod.java
@@ -100,7 +100,7 @@ public abstract class AbstractApiMethod extends HttpClient {
         }
         if (typePath.contains(":")) {
             methodType = HttpMethodType.valueOf(typePath.split(":")[0]);
-            methodPath = typePath.split(methodType + ":")[1];
+            methodPath = StringUtils.substringAfter(typePath, methodType + ":");
 
         } else {
             methodType = HttpMethodType.valueOf(typePath);

--- a/carina-api/src/test/java/com/qaprosoft/apitools/validation/mock/method/DeleteUserMethod.java
+++ b/carina-api/src/test/java/com/qaprosoft/apitools/validation/mock/method/DeleteUserMethod.java
@@ -1,0 +1,9 @@
+package com.qaprosoft.apitools.validation.mock.method;
+
+import com.qaprosoft.carina.core.foundation.api.AbstractApiMethodV2;
+
+public class DeleteUserMethod extends AbstractApiMethodV2 {
+    public DeleteUserMethod() {
+        super();
+    }
+}

--- a/carina-api/src/test/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethodTest.java
+++ b/carina-api/src/test/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethodTest.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package com.qaprosoft.carina.core.foundation.api;
 
+import com.qaprosoft.apitools.validation.mock.method.DeleteUserMethod;
 import com.qaprosoft.carina.core.foundation.api.ssl.PutDocMethod;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -22,11 +23,18 @@ import org.testng.annotations.Test;
 public class AbstractApiMethodTest {
 
     private final static String BODY_CONTENT = "{\"key\": \"value\"}";
+    private final static String EXPECTED_METHOD_PATH_URL = "https://jsonplaceholder.typicode.com/users/1";
 
     @Test
     public void testGetRequestBodyMethod() {
         PutDocMethod putDocMethod = new PutDocMethod();
         putDocMethod.setBodyContent(BODY_CONTENT);
         Assert.assertEquals(putDocMethod.getRequestBody(), BODY_CONTENT);
+    }
+
+    @Test
+    public void testInitMethod() {
+        DeleteUserMethod api = new DeleteUserMethod();
+        Assert.assertEquals(api.methodPath, EXPECTED_METHOD_PATH_URL);
     }
 }

--- a/carina-api/src/test/resources/api.properties
+++ b/carina-api/src/test/resources/api.properties
@@ -1,3 +1,4 @@
 PutDocMethod=PUT:${base_url}
 NoContentTypeMethod=GET:${base_url}/mock1
 XmlContentTypeMethod=GET:${base_url}/mock2
+DeleteUserMethod=DELETE:https://jsonplaceholder.typicode.com/users/1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed "Incorrect url for API call which is hard coded in api.properties #1564" ticket's bug.
<!--- Describe your changes in details -->
Found bug in the init method of AbstractApiMethod class. After not correct splitting methodPath field got incorrect url. Changed splitting logic (103 line). Created unit-test for the method in AbstractApiMethodTest class. Added url-query to api.properties file.
