### PR TITLE
build-snapshot: Adding new queryparam value scope=tester in AppcenterManager

### DIFF
--- a/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
+++ b/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
@@ -224,7 +224,7 @@ public class AppCenterManager {
                     queryParams,
                     HttpMethod.GET);
             JsonNode buildList = restTemplate.exchange(retrieveList, JsonNode.class).getBody();
-            LOGGER.debug("Available Builds JSON: " + buildList);
+            LOGGER.info("Available Builds JSON: " + buildList);
 
             if (buildList.size() > 0) {
                 int buildLimiter = 0;

--- a/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
+++ b/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
@@ -213,7 +213,7 @@ public class AppCenterManager {
      */
     private String scanAppForBuild(Map<String, String> apps, String buildType, String version) {
         for (String currentApp : apps.keySet()) {
-            LOGGER.info("Scanning App {}", currentApp);
+            LOGGER.info("Scanning App " + currentApp);
             MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
             queryParams.add("published_only", "true");
             queryParams.add("scope", "tester");
@@ -224,7 +224,7 @@ public class AppCenterManager {
                     queryParams,
                     HttpMethod.GET);
             JsonNode buildList = restTemplate.exchange(retrieveList, JsonNode.class).getBody();
-            LOGGER.info("Available Builds JSON: {}", buildList);
+            LOGGER.debug("Available Builds JSON: " + buildList);
 
             if (buildList.size() > 0) {
                 int buildLimiter = 0;

--- a/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
+++ b/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
@@ -216,6 +216,7 @@ public class AppCenterManager {
             LOGGER.info("Scanning App " + currentApp);
             MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
             queryParams.add("published_only", "true");
+            queryParams.add("scope", "tester");
 
             RequestEntity<String> retrieveList = buildRequestEntity(
                     HOST_URL,
@@ -269,6 +270,7 @@ public class AppCenterManager {
     private String getLatestBuildDate(String app, String appUpdatedAt) {
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
         queryParams.add("published_only", "true");
+        queryParams.add("scope", "tester");
 
         RequestEntity<String> retrieveList = buildRequestEntity(
                 HOST_URL,

--- a/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
+++ b/carina-appcenter/src/main/java/com/qaprosoft/appcenter/AppCenterManager.java
@@ -213,7 +213,7 @@ public class AppCenterManager {
      */
     private String scanAppForBuild(Map<String, String> apps, String buildType, String version) {
         for (String currentApp : apps.keySet()) {
-            LOGGER.info("Scanning App " + currentApp);
+            LOGGER.info("Scanning App {}", currentApp);
             MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
             queryParams.add("published_only", "true");
             queryParams.add("scope", "tester");
@@ -224,7 +224,7 @@ public class AppCenterManager {
                     queryParams,
                     HttpMethod.GET);
             JsonNode buildList = restTemplate.exchange(retrieveList, JsonNode.class).getBody();
-            LOGGER.info("Available Builds JSON: " + buildList);
+            LOGGER.info("Available Builds JSON: {}", buildList);
 
             if (buildList.size() > 0) {
                 int buildLimiter = 0;


### PR DESCRIPTION
Adding **scope=tester** to queryparam due to observed developer builds not intended for public use being made available in AppCenter. These builds have a unique package name which differs from test parameters and is causing failure to launch problems.

