### PR TITLE
#1650: moved testrun labels registration when first test starts

### DIFF
--- a/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
+++ b/carina-core/src/main/java/com/qaprosoft/carina/core/foundation/listeners/CarinaListener.java
@@ -202,6 +202,13 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
             Label.attachToTestRun("sha1", sha1);
         }
         
+        LOGGER.info("CARINA_CORE_VERSION: " + getCarinaVersion());
+    }
+
+	@Override
+    public void onStart(ITestContext context) {
+        LOGGER.debug("CarinaListener->OnTestStart(ITestContext context): " + context.getName());
+        
         /*
          * To support multi-suite declaration as below we have to init test run labels at once only!
          * <suite-files>
@@ -211,16 +218,10 @@ public class CarinaListener extends AbstractTestListener implements ISuiteListen
          */
         
         if (!this.isRunLabelsRegistered) {
-            attachTestRunLabels(suite);
+            attachTestRunLabels(context.getSuite());
             this.isRunLabelsRegistered = true;
         }
-
-        LOGGER.info("CARINA_CORE_VERSION: " + getCarinaVersion());
-    }
-
-	@Override
-    public void onStart(ITestContext context) {
-        LOGGER.debug("CarinaListener->OnTestStart(ITestContext context): " + context.getName());
+        
         super.onStart(context);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
