### PR TITLE
Hotfix for AmazonS3Manager

### DIFF
--- a/carina-aws-s3/src/main/java/com/qaprosoft/amazon/AmazonS3Manager.java
+++ b/carina-aws-s3/src/main/java/com/qaprosoft/amazon/AmazonS3Manager.java
@@ -312,8 +312,9 @@ public class AmazonS3Manager {
                     }
                 }
             }
+            boolean isTruncated = objBuilds.isTruncated();
             objBuilds = s3client.listNextBatchOfObjects(objBuilds);
-        } while (objBuilds.isTruncated() && ++i < limit);
+        } while (isTruncated && ++i < limit);
 
         if (latestBuild == null) {
             LOGGER.error("Unable to find S3 build artifact by pattern: " + pattern);

--- a/carina-aws-s3/src/main/java/com/qaprosoft/amazon/AmazonS3Manager.java
+++ b/carina-aws-s3/src/main/java/com/qaprosoft/amazon/AmazonS3Manager.java
@@ -295,6 +295,7 @@ public class AmazonS3Manager {
 
         int i = 0;
         int limit = 100;
+        boolean isTruncated = false;
         // by default S3 return only 1000 objects summary so need while cycle here
         do {
             LOGGER.info("looking for s3 artifact using iteration #" + i);
@@ -312,7 +313,7 @@ public class AmazonS3Manager {
                     }
                 }
             }
-            boolean isTruncated = objBuilds.isTruncated();
+            isTruncated = objBuilds.isTruncated();
             objBuilds = s3client.listNextBatchOfObjects(objBuilds);
         } while (isTruncated && ++i < limit);
 


### PR DESCRIPTION
Hotfix for AmazonS3Manager. 
Currently, it is impossible to get objects from S3 if there are more than 1000 objects. 

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
