### PR TITLE
#1690: attempt to reuse driver call retries for "cannot determine loa…

### DIFF
--- a/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
+++ b/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
@@ -113,7 +113,7 @@ public class SpecialKeywords {
     
     public final static String DRIVER_CONNECTION_REFUSED = "Driver connection refused";
     public final static String DRIVER_CONNECTION_REFUSED2 = "Expected to read a START_MAP but instead have: END. Last 0 characters read";
-    public final static String DRIVER_CANNOT_DETERMINE_LOADING_STATUS = "cannot determine loading status from target frame detached";
+    public final static String DRIVER_TARGET_FRAME_DETACHED = "target frame detached";
     public final static String DRIVER_NO_SUCH_WINDOW = "no such window: window was already closed";
 
     

--- a/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
+++ b/carina-commons/src/main/java/com/qaprosoft/carina/core/foundation/commons/SpecialKeywords.java
@@ -113,6 +113,7 @@ public class SpecialKeywords {
     
     public final static String DRIVER_CONNECTION_REFUSED = "Driver connection refused";
     public final static String DRIVER_CONNECTION_REFUSED2 = "Expected to read a START_MAP but instead have: END. Last 0 characters read";
+    public final static String DRIVER_CANNOT_DETERMINE_LOADING_STATUS = "cannot determine loading status from target frame detached";
     public final static String DRIVER_NO_SUCH_WINDOW = "no such window: window was already closed";
 
     

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/Screenshot.java
@@ -660,7 +660,6 @@ public class Screenshot {
 				|| message.contains("Illegal base64 character 2e")
 				|| message.contains("javascript error: Cannot read property 'outerHTML' of null")
 				|| message.contains("Driver connection refused")
-				|| message.contains("cannot determine loading status from target frame detached")
 				// carina based errors which means that driver is not ready for screenshoting
 				|| message.contains("Unable to open url during");
 

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/listener/EventFiringSeleniumCommandExecutor.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/listener/EventFiringSeleniumCommandExecutor.java
@@ -60,7 +60,7 @@ public class EventFiringSeleniumCommandExecutor extends HttpCommandExecutor {
                 String msg = response.getValue().toString();
                 if (msg.contains(SpecialKeywords.DRIVER_CONNECTION_REFUSED)
                         || msg.contains(SpecialKeywords.DRIVER_CONNECTION_REFUSED2)
-                        || msg.contains(SpecialKeywords.DRIVER_CANNOT_DETERMINE_LOADING_STATUS)) {
+                        || msg.contains(SpecialKeywords.DRIVER_TARGET_FRAME_DETACHED)) {
                     LOGGER.warn("Enabled command executor retries: " + msg);
                     CommonUtils.pause(pause);
                 } else {

--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/listener/EventFiringSeleniumCommandExecutor.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/listener/EventFiringSeleniumCommandExecutor.java
@@ -59,7 +59,8 @@ public class EventFiringSeleniumCommandExecutor extends HttpCommandExecutor {
 
                 String msg = response.getValue().toString();
                 if (msg.contains(SpecialKeywords.DRIVER_CONNECTION_REFUSED)
-                        || msg.contains(SpecialKeywords.DRIVER_CONNECTION_REFUSED2)) {
+                        || msg.contains(SpecialKeywords.DRIVER_CONNECTION_REFUSED2)
+                        || msg.contains(SpecialKeywords.DRIVER_CANNOT_DETERMINE_LOADING_STATUS)) {
                     LOGGER.warn("Enabled command executor retries: " + msg);
                     CommonUtils.pause(pause);
                 } else {


### PR DESCRIPTION
…ding status from target frame detached"

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
