### PR TITLE
excluded out-of-dated netty-tcnative-boringssl-static from azure module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,12 @@
                 <groupId>com.qaprosoft</groupId>
                 <artifactId>carina-azure</artifactId>
                 <version>1.0-SNAPSHOT</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.qaprosoft</groupId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in details -->

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
