### PR TITLE
[issue-1910] build-snapshot : updating the SuccessfulHttpStatus annotation to allow a message override 

### DIFF
--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethod.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethod.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 
+import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatus;
+import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
 import com.qaprosoft.carina.core.foundation.api.interceptor.InterceptorChain;
 import com.qaprosoft.carina.core.foundation.api.resolver.ContextResolverChain;
 import com.qaprosoft.carina.core.foundation.api.resolver.RequestStartLine;
@@ -48,7 +50,6 @@ import org.slf4j.event.Level;
 import com.qaprosoft.carina.core.foundation.api.http.ContentTypeEnum;
 import com.qaprosoft.carina.core.foundation.api.http.HttpClient;
 import com.qaprosoft.carina.core.foundation.api.http.HttpMethodType;
-import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
 import com.qaprosoft.carina.core.foundation.api.log.CarinaRequestBodyLoggingFilter;
 import com.qaprosoft.carina.core.foundation.api.log.CarinaResponseBodyLoggingFilter;
 import com.qaprosoft.carina.core.foundation.api.log.LoggingOutputStream;
@@ -212,6 +213,10 @@ public abstract class AbstractApiMethod extends HttpClient {
     }
 
     public void expectResponseStatus(HttpResponseStatusType status) {
+        expectResponseStatus(status.getResponseStatus());
+    }
+
+    public void expectResponseStatus(HttpResponseStatus status) {
         request.expect().statusCode(status.getCode());
         request.expect().statusLine(Matchers.containsString(status.getMessage()));
     }

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethodV2.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/AbstractApiMethodV2.java
@@ -34,7 +34,7 @@ import com.qaprosoft.apitools.validation.JsonKeywordsComparator;
 import com.qaprosoft.apitools.validation.JsonValidator;
 import com.qaprosoft.apitools.validation.XmlCompareMode;
 import com.qaprosoft.apitools.validation.XmlValidator;
-import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
+import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatus;
 import com.qaprosoft.carina.core.foundation.api.log.LoggingOutputStream;
 import com.qaprosoft.carina.core.foundation.api.resolver.ContextResolverChain;
 import org.json.JSONException;
@@ -209,9 +209,9 @@ public abstract class AbstractApiMethodV2 extends AbstractApiMethod {
      * @return restassured Response object
      */
     public Response callAPIExpectSuccess() {
-        HttpResponseStatusType statusType = ContextResolverChain.resolveSuccessfulHttpStatus(getAnchorElement())
+        HttpResponseStatus status = ContextResolverChain.resolveSuccessfulHttpStatus(getAnchorElement())
                 .orElseThrow(() -> new RuntimeException("To use this method please declare @SuccessfulHttpStatus for your AbstractApiMethod class"));
-        expectResponseStatus(statusType);
+        expectResponseStatus(status);
         return callAPI();
     }
 

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/http/HttpResponseStatus.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/http/HttpResponseStatus.java
@@ -13,26 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-package com.qaprosoft.carina.core.foundation.api.annotation;
+package com.qaprosoft.carina.core.foundation.api.http;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+/*
+ * HTTP Response status.
+ *
+ * @author Aaron Davis
+ */
+public final class HttpResponseStatus {
 
-import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
+    private final int code;
+    private final String message;
 
-@Target(value = { ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
-@Retention(value = RetentionPolicy.RUNTIME)
-public @interface SuccessfulHttpStatus {
+    public HttpResponseStatus(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
 
-    HttpResponseStatusType status();
+    public int getCode() {
+        return code;
+    }
 
-    String messageOverride() default "";
+    public String getMessage() {
+        return message;
+    }
 
-    @Target(value = { ElementType.PARAMETER })
-    @Retention(value = RetentionPolicy.RUNTIME)
-    @SuccessfulHttpStatus(status = HttpResponseStatusType.OK_200)
-    @interface Value {
+    public HttpResponseStatus withMessageOverride(String messageOverride) {
+        if (null == messageOverride || messageOverride.isEmpty() || messageOverride.equals(message)) {
+            return this;
+        } else {
+            return new HttpResponseStatus(code, messageOverride);
+        }
     }
 }

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/http/HttpResponseStatusType.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/http/HttpResponseStatusType.java
@@ -36,19 +36,13 @@ public enum HttpResponseStatusType {
     EXPECTATION_FAILED_417(417, "Expectation Failed"),
     UNPROCESSABLE_ENTITY_422(422, "Unprocessable Entity");
 
-    private final int code;
-    private final String message;
+    private final HttpResponseStatus responseStatus;
 
     HttpResponseStatusType(int code, String message) {
-        this.code = code;
-        this.message = message;
+        this.responseStatus = new HttpResponseStatus(code, message);
     }
 
-    public int getCode() {
-        return code;
-    }
-
-    public String getMessage() {
-        return message;
+    public HttpResponseStatus getResponseStatus() {
+        return responseStatus;
     }
 }

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/AnnotationContextResolver.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/AnnotationContextResolver.java
@@ -28,7 +28,7 @@ import com.qaprosoft.carina.core.foundation.api.annotation.PropertiesPath;
 import com.qaprosoft.carina.core.foundation.api.annotation.RequestTemplatePath;
 import com.qaprosoft.carina.core.foundation.api.annotation.ResponseTemplatePath;
 import com.qaprosoft.carina.core.foundation.api.annotation.SuccessfulHttpStatus;
-import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
+import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatus;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.Arrays;
@@ -96,10 +96,10 @@ class AnnotationContextResolver implements ContextResolver<Class<?>> {
     }
 
     @Override
-    public Optional<HttpResponseStatusType> resolveSuccessfulHttpStatus(Class<?> element) {
+    public Optional<HttpResponseStatus> resolveSuccessfulHttpStatus(Class<?> element) {
         return AnnotationUtils.findFirstAnnotationContextByChain(element, SuccessfulHttpStatus.class)
                 .map(AnnotationContext::getAnnotation)
-                .map(SuccessfulHttpStatus::status);
+                .map(annotation -> annotation.status().getResponseStatus().withMessageOverride(annotation.messageOverride()));
     }
 
     @Override

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/ContextResolver.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/ContextResolver.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package com.qaprosoft.carina.core.foundation.api.resolver;
 
-import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
+import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatus;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.Map;
@@ -39,7 +39,7 @@ interface ContextResolver<E extends AnnotatedElement> {
 
     Optional<String> resolveResponseTemplatePath(E element);
 
-    Optional<HttpResponseStatusType> resolveSuccessfulHttpStatus(E element);
+    Optional<HttpResponseStatus> resolveSuccessfulHttpStatus(E element);
 
     Optional<Map<String, ?>> resolvePathParams(E element);
 

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/ContextResolverChain.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/ContextResolverChain.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package com.qaprosoft.carina.core.foundation.api.resolver;
 
-import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
+import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatus;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.List;
@@ -67,7 +67,7 @@ public class ContextResolverChain {
         return getResolverValue(resolver -> resolver.resolveResponseTemplatePath(element), element);
     }
 
-    public static Optional<HttpResponseStatusType> resolveSuccessfulHttpStatus(AnnotatedElement element) {
+    public static Optional<HttpResponseStatus> resolveSuccessfulHttpStatus(AnnotatedElement element) {
         return getResolverValue(resolver -> resolver.resolveSuccessfulHttpStatus(element), element);
     }
 

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/MethodBasedContextResolver.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/MethodBasedContextResolver.java
@@ -36,7 +36,6 @@ import com.qaprosoft.carina.core.foundation.api.annotation.SuccessfulHttpStatus;
 import com.qaprosoft.carina.core.foundation.api.binding.RuntimeMethod;
 import com.qaprosoft.carina.core.foundation.api.http.HttpMethodType;
 import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatus;
-import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/MethodBasedContextResolver.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/MethodBasedContextResolver.java
@@ -35,6 +35,7 @@ import com.qaprosoft.carina.core.foundation.api.annotation.ResponseTemplatePath;
 import com.qaprosoft.carina.core.foundation.api.annotation.SuccessfulHttpStatus;
 import com.qaprosoft.carina.core.foundation.api.binding.RuntimeMethod;
 import com.qaprosoft.carina.core.foundation.api.http.HttpMethodType;
+import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatus;
 import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
 
 import java.lang.reflect.AnnotatedElement;
@@ -133,9 +134,9 @@ public class MethodBasedContextResolver implements ContextResolver<RuntimeMethod
     }
 
     @Override
-    public Optional<HttpResponseStatusType> resolveSuccessfulHttpStatus(RuntimeMethod element) {
+    public Optional<HttpResponseStatus> resolveSuccessfulHttpStatus(RuntimeMethod element) {
         return AnnotationUtils.findFirstAnnotationContextByChain(element, SuccessfulHttpStatus.class)
-                .map(context -> context.getValue(SuccessfulHttpStatus::status, o -> HttpResponseStatusType.valueOf(o.toString()), null));
+                .map(context -> context.getValue(annotation -> annotation.status().getResponseStatus().withMessageOverride(annotation.messageOverride()), HttpResponseStatus.class::cast, null));
     }
 
     @Override

--- a/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/PropertiesContextResolver.java
+++ b/carina-api/src/main/java/com/qaprosoft/carina/core/foundation/api/resolver/PropertiesContextResolver.java
@@ -17,7 +17,7 @@ package com.qaprosoft.carina.core.foundation.api.resolver;
 
 import com.qaprosoft.apitools.annotation.AnnotationUtils;
 import com.qaprosoft.carina.core.foundation.api.http.HttpMethodType;
-import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatusType;
+import com.qaprosoft.carina.core.foundation.api.http.HttpResponseStatus;
 import com.zebrunner.carina.utils.R;
 import org.apache.commons.lang3.StringUtils;
 
@@ -87,7 +87,7 @@ class PropertiesContextResolver implements ContextResolver<Class<?>> {
     }
 
     @Override
-    public Optional<HttpResponseStatusType> resolveSuccessfulHttpStatus(Class<?> element) {
+    public Optional<HttpResponseStatus> resolveSuccessfulHttpStatus(Class<?> element) {
         return Optional.empty();
     }
 

--- a/carina-api/src/test/java/com/qaprosoft/carina/core/foundation/api/http/HttpResponseStatusTest.java
+++ b/carina-api/src/test/java/com/qaprosoft/carina/core/foundation/api/http/HttpResponseStatusTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright 2020-2022 Zebrunner Inc (https://www.zebrunner.com).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.qaprosoft.carina.core.foundation.api.http;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class HttpResponseStatusTest {
+
+    @Test
+    public void testGetCode() {
+        int expectedCode = 200;
+        HttpResponseStatus status = new HttpResponseStatus(expectedCode, null);
+        Assert.assertEquals(status.getCode(), expectedCode);
+    }
+
+    @Test
+    public void testGetMessage() {
+        String expectedMessage = "expected message";
+        HttpResponseStatus status = new HttpResponseStatus(201, expectedMessage);
+        Assert.assertEquals(status.getMessage(), expectedMessage);
+    }
+
+    @Test
+    public void testWithMessageOverride() {
+        int expectedCode = 200;
+        String initialMessage = "initial message";
+        String messageOverride = "overridden message";
+        HttpResponseStatus status = new HttpResponseStatus(expectedCode, initialMessage).withMessageOverride(messageOverride);
+        Assert.assertEquals(status.getCode(), expectedCode);
+        Assert.assertEquals(status.getMessage(), messageOverride);
+    }
+
+    @Test
+    public void testWithNullMessageOverride() {
+        int expectedCode = 201;
+        String initialMessage = "initial message";
+        HttpResponseStatus status = new HttpResponseStatus(expectedCode, initialMessage);
+        HttpResponseStatus overriddenMessageStatus = status.withMessageOverride(null);
+        Assert.assertSame(status, overriddenMessageStatus);
+    }
+
+    @Test
+    public void testWithEmptyMessageOverride() {
+        int expectedCode = 201;
+        String initialMessage = "initial message";
+        HttpResponseStatus status = new HttpResponseStatus(expectedCode, initialMessage);
+        HttpResponseStatus overriddenMessageStatus = status.withMessageOverride("");
+        Assert.assertSame(status, overriddenMessageStatus);
+    }
+
+    @Test
+    public void testWithSameMessageOverride() {
+        int expectedCode = 201;
+        String initialMessage = "initial message";
+        HttpResponseStatus status = new HttpResponseStatus(expectedCode, initialMessage);
+        HttpResponseStatus overriddenMessageStatus = status.withMessageOverride(initialMessage);
+        Assert.assertSame(status, overriddenMessageStatus);
+    }
+}

--- a/carina-api/src/test/java/com/qaprosoft/carina/core/foundation/api/http/HttpResponseStatusTypeTest.java
+++ b/carina-api/src/test/java/com/qaprosoft/carina/core/foundation/api/http/HttpResponseStatusTypeTest.java
@@ -23,85 +23,97 @@ public class HttpResponseStatusTypeTest {
     @Test
     public void testOK_200Method() {
         HttpResponseStatusType type = HttpResponseStatusType.OK_200;
-        Assert.assertEquals(type.getCode(), 200);
-        Assert.assertEquals(type.getMessage(), "OK");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 200);
+        Assert.assertEquals(status.getMessage(), "OK");
     }
 
     @Test
     public void testCREATED_201Method() {
         HttpResponseStatusType type = HttpResponseStatusType.CREATED_201;
-        Assert.assertEquals(type.getCode(), 201);
-        Assert.assertEquals(type.getMessage(), "Created");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 201);
+        Assert.assertEquals(status.getMessage(), "Created");
     }
 
     @Test
     public void testACCEPTED_202Method() {
         HttpResponseStatusType type = HttpResponseStatusType.ACCEPTED_202;
-        Assert.assertEquals(type.getCode(), 202);
-        Assert.assertEquals(type.getMessage(), "Accepted");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 202);
+        Assert.assertEquals(status.getMessage(), "Accepted");
     }
 
     @Test
     public void testNO_CONTENT_204Method() {
         HttpResponseStatusType type = HttpResponseStatusType.NO_CONTENT_204;
-        Assert.assertEquals(type.getCode(), 204);
-        Assert.assertEquals(type.getMessage(), "No Content");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 204);
+        Assert.assertEquals(status.getMessage(), "No Content");
     }
 
     @Test
     public void testBAD_REQUEST_400Method() {
         HttpResponseStatusType type = HttpResponseStatusType.BAD_REQUEST_400;
-        Assert.assertEquals(type.getCode(), 400);
-        Assert.assertEquals(type.getMessage(), "Bad Request");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 400);
+        Assert.assertEquals(status.getMessage(), "Bad Request");
     }
 
     @Test
     public void testUNAUTHORIZED_401Method() {
         HttpResponseStatusType type = HttpResponseStatusType.UNAUTHORIZED_401;
-        Assert.assertEquals(type.getCode(), 401);
-        Assert.assertEquals(type.getMessage(), "Unauthorized");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 401);
+        Assert.assertEquals(status.getMessage(), "Unauthorized");
     }
 
     @Test
     public void testFORBIDDEN_403Method() {
         HttpResponseStatusType type = HttpResponseStatusType.FORBIDDEN_403;
-        Assert.assertEquals(type.getCode(), 403);
-        Assert.assertEquals(type.getMessage(), "Forbidden");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 403);
+        Assert.assertEquals(status.getMessage(), "Forbidden");
     }
 
     @Test
     public void testNOT_FOUND_404Method() {
         HttpResponseStatusType type = HttpResponseStatusType.NOT_FOUND_404;
-        Assert.assertEquals(type.getCode(), 404);
-        Assert.assertEquals(type.getMessage(), "Not Found");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 404);
+        Assert.assertEquals(status.getMessage(), "Not Found");
     }
 
     @Test
     public void testCONFLICT_409Method() {
         HttpResponseStatusType type = HttpResponseStatusType.CONFLICT_409;
-        Assert.assertEquals(type.getCode(), 409);
-        Assert.assertEquals(type.getMessage(), "Conflict");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 409);
+        Assert.assertEquals(status.getMessage(), "Conflict");
     }
 
     @Test
     public void testUNSUPPORTED_MEDIA_TYPE_415Method() {
         HttpResponseStatusType type = HttpResponseStatusType.UNSUPPORTED_MEDIA_TYPE_415;
-        Assert.assertEquals(type.getCode(), 415);
-        Assert.assertEquals(type.getMessage(), "Unsupported Media Type");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 415);
+        Assert.assertEquals(status.getMessage(), "Unsupported Media Type");
     }
 
     @Test
     public void testEXPECTATION_FAILED_417Method() {
         HttpResponseStatusType type = HttpResponseStatusType.EXPECTATION_FAILED_417;
-        Assert.assertEquals(type.getCode(), 417);
-        Assert.assertEquals(type.getMessage(), "Expectation Failed");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 417);
+        Assert.assertEquals(status.getMessage(), "Expectation Failed");
     }
 
     @Test
     public void testUNPROCESSABLE_ENTITY_422Method() {
         HttpResponseStatusType type = HttpResponseStatusType.UNPROCESSABLE_ENTITY_422;
-        Assert.assertEquals(type.getCode(), 422);
-        Assert.assertEquals(type.getMessage(), "Unprocessable Entity");
+        HttpResponseStatus status = type.getResponseStatus();
+        Assert.assertEquals(status.getCode(), 422);
+        Assert.assertEquals(status.getMessage(), "Unprocessable Entity");
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <module>carina-webdriver</module>
         <module>carina-core</module>
     </modules>
-    <!--repositories>
+    <repositories>
         <repository>
             <id>zebrunner_snapshots</id>
             <name>zebrunner Snapshots</name>
@@ -104,7 +104,7 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-    </repositories-->
+    </repositories>
     <profiles>
         <profile>
             <id>default</id>


### PR DESCRIPTION
Updating the SuccessfulHttpStatus annotation to have an optional message override.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in details -->
Solution for [issue-1910](https://github.com/zebrunner/carina/issues/1910). This updates the `@SuccessfulHttpStatus` annotation to allow an optional message override instead of using the hard coded statusLine value from the `HttpResponseStatusType` enum. If no override is given then the default message from the enum object will be used. This also updates the annotation converters and assertions to use the new `HttpResponseStatus` object built from the annotation and enum.

<!--- To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.
-->
