### PR TITLE
[Issue-2035] build-snapshot : ExtendedWebElement#isElementPresent should not throw StaleElementReferenceException

### DIFF
--- a/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/decorator/ExtendedWebElement.java
+++ b/carina-webdriver/src/main/java/com/qaprosoft/carina/core/foundation/webdriver/decorator/ExtendedWebElement.java
@@ -884,7 +884,16 @@ public class ExtendedWebElement implements IWebElement {
             throw new RuntimeException("There should be at least one ExpectedCondition!");
         }
 
-        return waitUntil(ExpectedConditions.or(conditions.toArray(new ExpectedCondition[0])), timeout);
+        try {
+            return waitUntil(ExpectedConditions.or(conditions.toArray(new ExpectedCondition[0])), timeout);
+        } catch (StaleElementReferenceException ignore) {
+            // If this ExtendedWebElement's element object is non-null and is stale or if the
+            // search context is a web element (e.g. it's a nested element) that
+            // is stale, then the various expected conditions can throw a stale element reference
+            // exception when checking the visibility or when finding child elements.
+            // In those cases we should catch the exception and return false.
+            return false;
+        }
     }
 
     /**

--- a/carina-webdriver/src/test/java/com/qaprosoft/carina/core/foundation/webdriver/decorator/ExtendedWebElementTest.java
+++ b/carina-webdriver/src/test/java/com/qaprosoft/carina/core/foundation/webdriver/decorator/ExtendedWebElementTest.java
@@ -1,0 +1,97 @@
+package com.qaprosoft.carina.core.foundation.webdriver.decorator;
+
+import org.mockito.Mockito;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class ExtendedWebElementTest {
+
+    @Test
+    public void test_isElementPresent_shouldReturnTrue_forVisibleElement() {
+        // Create the mocks
+        By by = Mockito.mock(By.class);
+        WebDriver driver = Mockito.mock(WebDriver.class);
+        WebElement foundElement = Mockito.mock(WebElement.class);
+        // Define the behavior for the mocks
+        Mockito.when(driver.findElement(by)).thenReturn(foundElement);
+        Mockito.when(foundElement.isDisplayed()).thenReturn(true);
+        // Execute the test
+        ExtendedWebElement element = new ExtendedWebElement(by, "testElementName", driver, driver);
+        Assert.assertTrue(element.isElementPresent());
+    }
+
+    @Test
+    public void test_isElementPresent_shouldReturnFalse_forNotVisibleElement() {
+        // Create the mocks
+        By by = Mockito.mock(By.class);
+        WebDriver driver = Mockito.mock(WebDriver.class);
+        WebElement foundElement = Mockito.mock(WebElement.class);
+        // Define the behavior for the mocks
+        Mockito.when(driver.findElement(by)).thenReturn(foundElement);
+        Mockito.when(foundElement.isDisplayed()).thenReturn(false);
+        // Execute the test
+        ExtendedWebElement element = new ExtendedWebElement(by, "testElementName", driver, driver);
+        Assert.assertFalse(element.isElementPresent(0L));
+    }
+
+    @Test
+    public void test_isElementPresent_shouldReturnFalse_forNotFoundElement() {
+        // Create the mocks
+        By by = Mockito.mock(By.class);
+        WebDriver driver = Mockito.mock(WebDriver.class);
+        // Define the behavior for the mocks
+        Mockito.when(driver.findElement(by)).thenThrow(new NoSuchElementException("noElementFound"));
+        // Execute the test
+        ExtendedWebElement element = new ExtendedWebElement(by, "testElementName", driver, driver);
+        Assert.assertFalse(element.isElementPresent(0L));
+    }
+
+    @Test
+    public void test_isElementPresent_shouldReturnFalse_forStaleFoundElement() {
+        // Create the mocks
+        By by = Mockito.mock(By.class);
+        WebDriver driver = Mockito.mock(WebDriver.class);
+        WebElement foundElement = Mockito.mock(WebElement.class);
+        // Define the behavior for the mocks
+        Mockito.when(driver.findElement(by)).thenReturn(foundElement);
+        Mockito.when(foundElement.isDisplayed()).thenThrow(new StaleElementReferenceException("staleFoundElement"));
+        // Execute the test
+        ExtendedWebElement element = new ExtendedWebElement(by, "testElementName", driver, driver);
+        Assert.assertFalse(element.isElementPresent(0L));
+    }
+
+    @Test
+    public void test_isElementPresent_shouldReturnTrue_forVisibleElement_fromElementSearchContext() {
+        // Create the mocks
+        By by = Mockito.mock(By.class);
+        WebDriver driver = Mockito.mock(WebDriver.class);
+        WebElement context = Mockito.mock(WebElement.class);
+        WebElement foundElement = Mockito.mock(WebElement.class);
+        // Define the behavior for the mocks
+        Mockito.when(context.findElements(by)).thenReturn(List.of(foundElement));
+        Mockito.when(foundElement.isDisplayed()).thenReturn(true);
+        // Execute the test
+        ExtendedWebElement element = new ExtendedWebElement(by, "testElementName", driver, context);
+        Assert.assertTrue(element.isElementPresent());
+    }
+
+    @Test
+    public void test_isElementPresent_shouldReturnFalse_forStaleSearchContext() {
+        // Create the mocks
+        By by = Mockito.mock(By.class);
+        WebDriver driver = Mockito.mock(WebDriver.class);
+        WebElement context = Mockito.mock(WebElement.class);
+        // Define the behavior for the mocks
+        Mockito.when(context.findElements(by)).thenThrow(new StaleElementReferenceException("staleSearchContext"));
+        // Execute the test
+        ExtendedWebElement element = new ExtendedWebElement(by, "testElementName", driver, context);
+        Assert.assertFalse(element.isElementPresent());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <module>carina-webdriver</module>
         <module>carina-core</module>
     </modules>
-    <!--repositories>
+    <repositories>
         <repository>
             <id>zebrunner_snapshots</id>
             <name>zebrunner Snapshots</name>
@@ -104,7 +104,7 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-    </repositories-->
+    </repositories>
     <profiles>
         <profile>
             <id>default</id>


### PR DESCRIPTION
The isElementPresent method can throw a StaleElementReferenceException in a couple of scenarios. These are if the object has a non-null `element` field that is stale or if the search context is a web element (e.g. it represents a nested element search) and the search context is stale.

This change wraps the execution of the wait to catch any StaleElementReferenceException and returns false in the case that one is caught. It also adds some unit tests for both true and false cases with mocking.