### PR TITLE
Issue-2019 : Updating TestNG version to 7.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <carina-proxy.version>1.0.0</carina-proxy.version>
 
         <!-- Testings -->
-        <testng.version>7.6.1</testng.version>
+        <testng.version>7.7.1</testng.version>
         <testng-foundation.version>2.0.1</testng-foundation.version>
         <!-- Logging -->
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
This simply bumps the version of TestNG to 7.7.1. I tested with the carina-demo tests. Some of those tests appear to be broken even without the changes (e.g. with the current latest version of Carina) but I'm not sure if that is due to the tests having an issue or if there is something wrong with my configuration. However, with the changes I wasn't seeing any different behavior than without (e.g. the same number of test failures and with the same errors).

[Issue-2019](https://github.com/zebrunner/carina/issues/2019)