### PR TITLE
docs: Updation of old TestNG resource links

### DIFF
--- a/docs/automation/web.md
+++ b/docs/automation/web.md
@@ -265,7 +265,7 @@ url=http://www.gsmarena.com
 capabilities.browserName=chrome
 ```
 
-The implemented test cases should be placed in a TestNG xml file according to the test group the test belongs to. You can find more details about TestNG configuration in the [official documentation](http://testng.org/doc/documentation-main.html).
+The implemented test cases should be placed in a TestNG xml file according to the test group the test belongs to. You can find more details about TestNG configuration in the [official documentation](https://testng.org/#_testng_xml).
 ```xml
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,6 @@
 * Install and configure JDK 11+
 * Install and configure [Apache Maven 3.6.0+](http://maven.apache.org/)
-* Download the latest version of [Eclipse](http://www.eclipse.org/downloads/) and install [TestNG plugin](http://testng.org/doc/download.html), maven-dependency-plugin connector and optionally lombok
+* Download the latest version of [Eclipse](http://www.eclipse.org/downloads/) and install [TestNG plugin](https://testng.org/#_download), maven-dependency-plugin connector and optionally lombok
 
 ### Generating project
 The easiest way to initialize a new project is to use Carina archetype, you will get correct project structure along with test samples. Run below command from any <b>empty folder</b>:


### PR DESCRIPTION
**Provide a general summary of your changes in the Title above**
The reference links to Testng website were broken/outdated, Hence it is updated to the new relevant URLs

**Describe your changes in details**
Updated the old links to the new relevant URLs

**To generate SNAPSHOT core build please assign "build-snapshot" label or type it in PR Title above.
        For example: "build-snapshot: my PR details".
        Email notification informs you about deployed snapshot build you can use for testing or about failure.**

NA, Doc change only.